### PR TITLE
Added 2022.2 Build support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'io.unthrottled'
-version '1.5.1'
+version '1.6.0'
 
 repositories {
   mavenCentral()

--- a/changelog/CHANGELOG.html
+++ b/changelog/CHANGELOG.html
@@ -1,5 +1,10 @@
 <h1 id="changelog">Changelog</h1>
 <hr>
+<h1 id="1-6-0">1.6.0</h1>
+<ul>
+  <li>Migrating MacOS users on 2022.2 builds to not use the provided themed title bar, as it has native support now.</li>
+  <li>2022.2 Build Support</li>
+</ul>
 <h1 id="1-5-1">1.5.1</h1>
 <ul>
   <li>Fixed 2022.1 compatability problems.</li>

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ---
 
+# 1.6.0
+
+- Migrating MacOS users on 2022.2 builds to not use the provided themed title bar, as it has native support now.
+- 2022.2 Build Support
+
 # 1.5.1
 
 - Fixed 2022.1 compatability problems.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,8 @@
 kotlin.code.style=official
 sinceBuildVersion=203.7148.57
-untilBuildVersion=221.*
+untilBuildVersion=222.*
+
+# Opt-out flag for bundling Kotlin standard library.
+# See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
+# suppress inspection "UnusedProperty"
+kotlin.stdlib.default.dependency = false

--- a/src/main/kotlin/io/unthrottled/themed/components/laf/LookAndFeelInstaller.kt
+++ b/src/main/kotlin/io/unthrottled/themed/components/laf/LookAndFeelInstaller.kt
@@ -2,6 +2,7 @@ package io.unthrottled.themed.components.laf
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.wm.impl.IdeBackgroundUtil
+import io.unthrottled.themed.components.legacy.LegacyMigration
 import io.unthrottled.themed.components.settings.Configurations
 import io.unthrottled.themed.components.ui.TitlePaneUI
 import io.unthrottled.themed.components.util.Constants.COMPLETION_SELECTION_ACTIVE
@@ -13,6 +14,7 @@ import javax.swing.UIManager
 
 object LookAndFeelInstaller {
   init {
+    LegacyMigration.migrateIfNecessary()
     installAllUIComponents()
   }
 

--- a/src/main/kotlin/io/unthrottled/themed/components/legacy/LegacyMigration.kt
+++ b/src/main/kotlin/io/unthrottled/themed/components/legacy/LegacyMigration.kt
@@ -1,0 +1,25 @@
+package io.unthrottled.themed.components.legacy
+
+import com.intellij.openapi.application.ex.ApplicationInfoEx
+import com.intellij.openapi.util.BuildNumber
+import com.intellij.openapi.util.SystemInfo
+import io.unthrottled.themed.components.settings.Configurations
+
+object LegacyMigration {
+  fun migrateIfNecessary() {
+    migrateUsersAwayFromTitlePane()
+  }
+
+  private val nativeTitlePaneBuild = BuildNumber.fromString("222.2680.4")
+  private fun migrateUsersAwayFromTitlePane() {
+    val build = ApplicationInfoEx.getInstanceEx().build
+    if (SystemInfo.isMac &&
+      Configurations.instance.isThemedTitleBar &&
+      // is the current build greater that the
+      // build that has native titlepane support
+      (nativeTitlePaneBuild?.compareTo(build) ?: 0) <= 0
+    ) {
+      Configurations.instance.isThemedTitleBar = false
+    }
+  }
+}

--- a/src/main/kotlin/io/unthrottled/themed/components/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/themed/components/notification/UpdateNotification.kt
@@ -11,7 +11,8 @@ val UPDATE_MESSAGE: String =
   """
       What's New?<br>
       <ul>
-      <li>2021.3 Build Support</li>
+      <li>2022.1 Build Support</li>
+      <li>Disabling Themed Titlebar for MacOS Users on 2022, as it has native support now.</li>
       </ul>
       <br>Please see the <a href="https://github.com/Unthrottled/themed-components/blob/master/changelog/CHANGELOG.md">Changelog</a> for more details.
       <br>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Added 2022.2 Build support 
- Migrating MacOS users on 2022.2 builds to not use the provided themed title bar, as it has native support now.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project (`./gradlew check` passes clean).
    - Tip: If you have lint issues just run `./gradlew :ktlintMainSourceSetFormat`.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
